### PR TITLE
change FPU flags to use single precision FPU

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -144,7 +144,7 @@ env.Append(
 
 fpv_version = "4-sp"
 if board.id == "portenta_c33":
-    fpv_version = "5"
+    fpv_version = "5-sp"
 
 env.Append(
     LINKFLAGS=[

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -142,14 +142,10 @@ env.Append(
 # Add FPU flags
 #
 
-fpv_version = "4-sp"
-if board.id == "portenta_c33":
-    fpv_version = "5-sp"
-
 env.Append(
     LINKFLAGS=[
         "-mfloat-abi=hard",
-        "-mfpu=fpv%s-d16" % fpv_version
+        "-mfpu=fpv%s-sp-d16" % ("5" if board.id == "portenta_c33" else "4"),
     ]
 )
 


### PR DESCRIPTION
The Cortex-M33F has a single precision fpu, thus the linker fpu settings need to be set to -mfpu=fpv-sp-d16. Otherwise all calls to the floating point abi will lead to a crash.

You can check by just compiling any code with this framework and executing:

float a,b,c;
a= 2.0f;
b=3.0f;
a = powf(b,c);