### PR TITLE
Change jlink_device to R7FA6M5

### DIFF
--- a/boards/portenta_c33.json
+++ b/boards/portenta_c33.json
@@ -26,7 +26,7 @@
     "variant": "PORTENTA_C33"
   },
   "debug": {
-    "jlink_device": "RA6M5",
+    "jlink_device": "R7FA6M5",
     "svd_path": "R7FA6M5BH.svd"
   },
   "frameworks": [


### PR DESCRIPTION
"RA6M5" is unknown to J-Link, debugging is not possible with this setting (see console output below) Should be "R7FA6M5"

Console Output for failed Debug session:
[...]
rs:      none
Target interface:
              SWD
Target interface
 speed:        5000kHz
Target 
endian:                 little

Connecting to J-Link...
J-Link is connected.
Failed to get index for device name 'RA6M5'.GDBServer will be closed... Shutting down...